### PR TITLE
Don't divide by zero in log

### DIFF
--- a/flask/cluster.py
+++ b/flask/cluster.py
@@ -62,7 +62,9 @@ def analyze_uclust():
     f.close()
     utils.log('parts: ' + str(total_parts))
     utils.log('hits: ' + str(hits))
-    utils.log('average hit identity: ' + str(total_identity / hits))
+
+    if hits > 0:
+        utils.log('average hit identity: ' + str(total_identity / hits))
 
 
 def uclust2clusters():


### PR DESCRIPTION
This gates zero division so that SBOLExplorer isn't crashed by logging.